### PR TITLE
During upgrade: Prevent 'openssh-server' to open a dialog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ check: $(BARCO)
 setup:
 	# Update apt and upgrade packages
 	@sudo apt update
-	@sudo apt upgrade -y
+	@sudo DEBIAN_FRONTEND=noninteractive apt upgrade -y
 
 	# Install OS dependencies
 	@sudo apt install -y bash libarchive-tools lsb-release wget software-properties-common gnupg


### PR DESCRIPTION
During `apt upgrade -y`, openssh-server opens a dialog asking how to handle the ssh-server configuration files.
This blocks the installation.

This pull request prevents this dialog