### PR TITLE
Fixes for execve() argv[0] and argv[1]

### DIFF
--- a/src/barco.c
+++ b/src/barco.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
   }
 
   config.cmd = (char *)cmd->sval[0];
-  config.arg = (char *)arg->sval[0];
+  config.arg = arg->count > 0 ? (char *)arg->sval[0] : NULL;
   config.mnt = (char *)mnt->sval[0];
 
   // Check if barco is running as root

--- a/src/container.c
+++ b/src/container.c
@@ -44,7 +44,9 @@ int container_start(void *arg) {
   // argv must be NULL terminated
   char *argv[] = {config->cmd, config->arg, NULL};
   if (execve(config->cmd, argv, NULL)) {
-    log_error("failed to execve '%s %s': %m", config->cmd, argv);
+    log_error("failed to execve '%s%s%s': %m", config->cmd,
+              config->arg == NULL ? "" : " ",
+              config->arg == NULL ? "" : config->arg);
     return -1;
   }
   log_debug("container started...");

--- a/src/container.c
+++ b/src/container.c
@@ -42,7 +42,7 @@ int container_start(void *arg) {
             config->cmd, config->arg, config->mnt);
   log_info("### BARCONTAINER STARTING - type 'exit' to quit ###");
   // argv must be NULL terminated
-  char *argv[] = {config->arg, NULL};
+  char *argv[] = {config->cmd, config->arg, NULL};
   if (execve(config->cmd, argv, NULL)) {
     log_error("failed to execve '%s %s': %m", config->cmd, argv);
     return -1;


### PR DESCRIPTION
These changes are a bit more complete than [my original suggestion](https://old.reddit.com/r/C_Programming/comments/15lgpqo/barco_linux_containers_from_scratch_in_c/jvc7n8y/).