### PR TITLE
Revert "Fixes for execve() argv[0] and argv[1]"

### DIFF
--- a/src/barco.c
+++ b/src/barco.c
@@ -81,7 +81,7 @@ int main(int argc, char **argv) {
   }
 
   config.cmd = (char *)cmd->sval[0];
-  config.arg = arg->count > 0 ? (char *)arg->sval[0] : NULL;
+  config.arg = (char *)arg->sval[0];
   config.mnt = (char *)mnt->sval[0];
 
   // Check if barco is running as root

--- a/src/container.c
+++ b/src/container.c
@@ -42,11 +42,9 @@ int container_start(void *arg) {
             config->cmd, config->arg, config->mnt);
   log_info("### BARCONTAINER STARTING - type 'exit' to quit ###");
   // argv must be NULL terminated
-  char *argv[] = {config->cmd, config->arg, NULL};
+  char *argv[] = {config->arg, NULL};
   if (execve(config->cmd, argv, NULL)) {
-    log_error("failed to execve '%s%s%s': %m", config->cmd,
-              config->arg == NULL ? "" : " ",
-              config->arg == NULL ? "" : config->arg);
+    log_error("failed to execve '%s %s': %m", config->cmd, argv);
     return -1;
   }
   log_debug("container started...");


### PR DESCRIPTION
Reverts lucavallin/barco#2

This change makes the container non-interactive.