### PR TITLE
Fixes Build bug for third-party log libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ $(BARCO): format lint dir $(OBJS)
 # Build third-party libraries
 $(LIB_ARGTABLE_NAME).o: dir $(LIB_ARGTABLE_SRC)
 	@$(CC) $(CFLAGS) -o $(BUILD_DIR)/$(LIB_ARGTABLE_NAME).o -c $(LIB_ARGTABLE_SRC)
-$(LIB_LOG_NAME).o: dir $(LIB_ARGTABLE_SRC)
+$(LIB_LOG_NAME).o: dir $(LIB_LOG_SRC)
 	@$(CC) $(CFLAGS) -o $(BUILD_DIR)/$(LIB_LOG_NAME).o -c $(LIB_LOG_SRC) $(LIB_LOG_FLAGS)
 
 # Run CUnit tests


### PR DESCRIPTION
Hi ,lucavallin!
I hope this message finds you well. Thank you for the excellent code！
I have identified an error in the Makefiles where the Log Library should be dependent on the 'LIB_LOG_SRC', rather than the 'LIB_ARGTABLE_SRC' .

This pull request addresses the issue by correcting the dependency of the Log Library to rely on the 'log.c' file instead of the 'argtable3.c' file.
