### PR TITLE
docs: Fix small typo in user_namespace_prepare_mappings() comment

### DIFF
--- a/src/user.c
+++ b/src/user.c
@@ -90,7 +90,7 @@ int user_namespace_prepare_mappings(pid_t pid, int fd) {
       // The first number is the starting uid / gid of the parent
       // namespace, the second number is the starting uid / gid of the child
       // namespace, and the third number is the number of uids / gids to map.
-      // This configuration tells the kernel that the preant uid / gid 0 is
+      // This configuration tells the kernel that the parent uid / gid 0 is
       // mapped to USER_NAMESPACE_UID_CHILD_RANGE_START uid of the child
       if (dprintf(map_fd, "%d %d %d\n", USER_NAMESPACE_UID_PARENT_RANGE_START,
                   USER_NAMESPACE_UID_CHILD_RANGE_START,


### PR DESCRIPTION
### Summary

Fixed a small typo in a comment inside `user_namespace_prepare_mappings()`.

### What was changed

- Corrected the word "preant" to "parent" in a comment.

### Notes

- No functional code changes.
- Just a minor comment correction for clarity.

This is my first contribution to this project. Happy to help improve documentation quality!